### PR TITLE
Fix i18n default locale and middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,32 +1,20 @@
-import createMiddleware from 'next-intl/middleware';
-import {NextRequest, NextResponse} from 'next/server';
-import {locales} from '@/config';
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
 
-export default async function middleware(request: NextRequest) {
-  
- 
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const locale = request.nextUrl.locale || "br";
 
+  // Redirect root URL to default locale
+  if (pathname === "/") {
+    return NextResponse.redirect(new URL(`/${locale}`, request.url));
+  }
 
-  // Step 1: Use the incoming request (example)
-  const defaultLocale = request.headers.get('fvstudios-locale') || 'br';
- 
-  // Step 2: Create and call the next-intl middleware (example)
-  const handleI18nRouting = createMiddleware({
-    locales,
-    defaultLocale
-    
-  });
-  const response = handleI18nRouting(request);
- 
-  // Step 3: Alter the response (example)
-  response.headers.set('fvstudios-locale', defaultLocale);
-
-
- 
-  return response;
+  return NextResponse.next();
 }
- 
+
 export const config = {
-  // Match only internationalized pathnames
-  matcher: ['/', '/(br|en)/:path*']
+  matcher: [
+    "/((?!_next|api|static|favicon.ico).*)",
+  ],
 };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -34,6 +34,11 @@ const nextConfig = {
       },
     ],
   },
+  i18n: {
+    locales: ["br", "en"],
+    defaultLocale: "br",
+    localeDetection: true,
+  },
 };
 
 export default withNextIntl(withNextra(nextConfig));


### PR DESCRIPTION
## Summary
- add explicit i18n configuration to Next.js config
- simplify middleware to redirect root path to default locale

## Testing
- `npm run lint` *(fails: Invalid Options)*
- `npm run build` *(partially runs until static page generation)*

------
https://chatgpt.com/codex/tasks/task_e_68745aadcf288328ab0a92fc715f4ec8