### PR TITLE
Fix ESLint 9 configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,16 @@
+import { FlatCompat } from '@eslint/eslintrc';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const compat = new FlatCompat({
+  baseDirectory: dirname(fileURLToPath(import.meta.url)),
+});
+
+const config = [
+  {
+    ignores: ['.next/**', 'public/**'],
+  },
+  ...compat.extends('next/core-web-vitals'),
+];
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint . --ext .js,.ts,.tsx"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",


### PR DESCRIPTION
## Summary
- adopt flat config with ESLint v9
- ignore build output
- run ESLint directly instead of `next lint`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68745d1b17488328ad1c387b1f99e6bd