### PR TITLE
Update calendar layout with translations

### DIFF
--- a/app/[locale]/(protected)/app/calendar/layout.tsx
+++ b/app/[locale]/(protected)/app/calendar/layout.tsx
@@ -1,9 +1,15 @@
-export const metadata = {
-  title: "Calender",
-};
+"use client";
+
+import { useTranslations } from "next-intl";
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
-  return <>{children}</>;
+  const t = useTranslations("CalendarApp");
+  return (
+    <>
+      <title>{t("pageTitle")}</title>
+      {children}
+    </>
+  );
 };
 
 export default Layout;

--- a/messages/br.json
+++ b/messages/br.json
@@ -114,6 +114,7 @@
     "addBoard": "اضافة قائمة جديدة"
   },
   "CalendarApp": {
+    "pageTitle": "Calendário",
     "addEvent": "اضافة حدث",
     "shortDesc": "قم بسحب وإسقاط الحدث الخاص بك أو انقر في التقويم",
     "filter": "فلتر"

--- a/messages/en.json
+++ b/messages/en.json
@@ -106,6 +106,7 @@
     "addBoard": "Add Board"
   },
   "CalendarApp": {
+    "pageTitle": "Calendar",
     "addEvent": "Add Event",
     "shortDesc": "Drag and drop your event or click in the calendar",
     "filter": "FILTER"


### PR DESCRIPTION
## Summary
- internationalize calendar page title using next-intl
- add Portuguese and English calendar translations

## Testing
- `npm run lint`
- `npm run build` *(fails: Invalid Options: Unknown options: useEslintrc, extensions)*

------
https://chatgpt.com/codex/tasks/task_e_68746a8baa3083288c3428eebe20ba76