### PR TITLE
Fix default locale and BR routing

### DIFF
--- a/app/[locale]/(protected)/app/chat/[id]/page.tsx
+++ b/app/[locale]/(protected)/app/chat/[id]/page.tsx
@@ -34,13 +34,13 @@ const socials = [
     },
 ];
 
-const ChatPageSingle = async ({ params: { id } }: { params: { id: string }; }) => {
+const ChatPageSingle = async ({ params: { locale, id } }: { params: { locale: string; id: string } }) => {
  
     const { chat, contact } = await getChatsByContactId(id)
     const profile = await getProfileUser()
 
     if (!contact) {
-        redirect({ href: '/app/chat', locale: 'en' })
+        redirect({ href: '/app/chat', locale })
     }
 
     return (

--- a/app/[locale]/(protected)/app/projects/page.tsx
+++ b/app/[locale]/(protected)/app/projects/page.tsx
@@ -1,8 +1,8 @@
 
 import { redirect } from '@/components/navigation'
 
-const ProjectPage = () => {
-  redirect({ href: '/app/projects/grid', locale: 'en' })
+const ProjectPage = ({ params: { locale } }: { params: { locale: string } }) => {
+  redirect({ href: '/app/projects/grid', locale })
   return null
 }
 

--- a/app/[locale]/(protected)/ecommerce/backend/page.tsx
+++ b/app/[locale]/(protected)/ecommerce/backend/page.tsx
@@ -1,7 +1,7 @@
 "use client";
-import { redirect } from "@/components/navigation";
+import { redirect } from '@/components/navigation';
 const Backend = () => {
-  redirect({ href: '/ecommerce/backend/add-product', locale: 'en' })
+  redirect({ href: '/ecommerce/backend/add-product' })
   return null;
 };
 

--- a/app/[locale]/(protected)/ecommerce/page.tsx
+++ b/app/[locale]/(protected)/ecommerce/page.tsx
@@ -1,7 +1,7 @@
 "use client";
-import { redirect } from "@/components/navigation";
+import { redirect } from '@/components/navigation';
 const Backend = () => {
-  redirect({ href: '/ecommerce/frontend', locale: 'en' })
+  redirect({ href: '/ecommerce/frontend' })
   return null;
 };
 

--- a/app/[locale]/(protected)/layout.tsx
+++ b/app/[locale]/(protected)/layout.tsx
@@ -6,11 +6,17 @@ import ThemeCustomize from '@/components/partials/customizer'
 import DashCodeHeader from '@/components/partials/header'
 import { auth } from "@/lib/auth";
 import { redirect } from "@/components/navigation";
-const layout = async ({ children }: { children: React.ReactNode }) => {
+const layout = async ({
+    children,
+    params: { locale },
+}: {
+    children: React.ReactNode;
+    params: { locale: string };
+}) => {
     const session = await auth();
 
     if (!session) {
-        redirect({ href: '/', locale: 'en' })
+        redirect({ href: '/', locale })
     }
     return (
         <LayoutProvider >

--- a/app/[locale]/auth/login2/page.tsx
+++ b/app/[locale]/auth/login2/page.tsx
@@ -4,7 +4,7 @@ import Social from "@/components/partials/auth/social";
 import Image from "next/image";
 import Copyright from "@/components/partials/auth/copyright";
 import Logo from "@/components/logo";
-const Login2 = () => {
+const Login2 = ({ params: { locale } }: { params: { locale: string } }) => {
   return (
     <>
       <div className="flex w-full items-center overflow-hidden min-h-dvh h-dvh basis-full">
@@ -30,7 +30,7 @@ const Login2 = () => {
                   </div>
                 </div>
                 <div className="max-w-[242px] mx-auto mt-8 w-full">
-                  <Social locale="en" />
+                  <Social locale={locale} />
                 </div>
                 <div className="md:max-w-[345px] mt-6 mx-auto font-normal text-default-500 md:mt-12 uppercase text-sm">
                   Don’t have an account?{" "}

--- a/app/[locale]/auth/login3/page.tsx
+++ b/app/[locale]/auth/login3/page.tsx
@@ -4,7 +4,7 @@ import LoginForm from "@/components/partials/auth//login-form";
 import Image from "next/image";
 import Logo from "@/components/logo";
 
-const Login3 = () => {
+const Login3 = ({ params: { locale } }: { params: { locale: string } }) => {
   return (
     <>
       <div
@@ -48,7 +48,7 @@ const Login3 = () => {
                 </div>
               </div>
               <div className="max-w-[242px] mx-auto mt-8 w-full">
-                <Social locale="en" />
+                <Social locale={locale} />
               </div>
               <div className="mx-auto font-normal text-default-500  2xl:mt-12 mt-6 uppercase text-sm text-center">
                 {` Don't`} have an account?

--- a/app/[locale]/auth/register/page.tsx
+++ b/app/[locale]/auth/register/page.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import Copyright from "@/components/partials/auth/copyright";
 import Logo from "@/components/partials/auth/logo";
 import Social from "@/components/partials/auth/social";
-const Register = () => {
+const Register = ({ params: { locale } }: { params: { locale: string } }) => {
   return (
     <>
       <div className="flex w-full items-center overflow-hidden min-h-dvh h-dvh basis-full">
@@ -55,7 +55,7 @@ const Register = () => {
                   </div>
                 </div>
                 <div className="max-w-[242px] mx-auto mt-8 w-full">
-                  <Social locale={""} />
+                  <Social locale={locale} />
                 </div>
                 <div className="max-w-[225px] mx-auto font-normal text-default-500  2xl:mt-12 mt-6 uppercase text-sm">
                   Already registered?

--- a/app/[locale]/auth/register2/page.tsx
+++ b/app/[locale]/auth/register2/page.tsx
@@ -6,7 +6,7 @@ import Logo from "@/components/logo";
 
 // image import
 
-const Register2 = () => {
+const Register2 = ({ params: { locale } }: { params: { locale: string } }) => {
   return (
     <>
       <div className="flex w-full items-center overflow-hidden min-h-dvh h-dvh basis-full">
@@ -32,7 +32,7 @@ const Register2 = () => {
                   </div>
                 </div>
                 <div className="max-w-[242px] mx-auto mt-8 w-full">
-                  <Social locale="" />
+                    <Social locale={locale} />
                 </div>
                 <div className="max-w-[225px] mx-auto font-normal text-default-500  2xl:mt-12 mt-6 uppercase text-sm">
                   Already registered?

--- a/app/[locale]/auth/register3/page.tsx
+++ b/app/[locale]/auth/register3/page.tsx
@@ -4,7 +4,7 @@ import Social from "@/components/partials/auth//social";
 import Image from "next/image";
 import Logo from "@/components/logo";
 
-const Register3 = () => {
+const Register3 = ({ params: { locale } }: { params: { locale: string } }) => {
   return (
     <>
       <div
@@ -50,8 +50,8 @@ const Register3 = () => {
                   Or continue with
                 </div>
               </div>
-              <div className="max-w-[242px] mx-auto mt-8 w-full">
-                <Social locale="" />
+                <div className="max-w-[242px] mx-auto mt-8 w-full">
+                  <Social locale={locale} />
               </div>
               <div className="max-w-[225px] mx-auto font-normal text-default-500  2xl:mt-12 mt-6 uppercase text-sm">
                 Already registered?

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -12,11 +12,16 @@ import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 import DirectionProvider from "@/providers/direction-provider";
 import AuthProvider from "@/providers/auth.provider";
+import { locales } from "@/config";
 
 export const metadata: Metadata = {
   title: "FVSTUDIOS admin Template",
   description: "created by codeshaper",
 };
+
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }));
+}
 
 export default async function RootLayout({
   children,

--- a/components/navigation.ts
+++ b/components/navigation.ts
@@ -1,5 +1,5 @@
 import {createNavigation} from 'next-intl/navigation';
-import {locales} from '@/config';
+import {locales, defaultLocale} from '@/config';
  
 export const {Link, redirect, usePathname, useRouter} =
-  createNavigation({locales,});
+  createNavigation({ locales, defaultLocale });

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,3 +1,4 @@
 export const locales = ['br', 'en'];
+export const defaultLocale = 'br';
 
-export const baseURL = process.env.NEXT_PUBLIC_SITE_URL + "/api";
+export const baseURL = process.env.NEXT_PUBLIC_SITE_URL + '/api';

--- a/i18n/config.ts
+++ b/i18n/config.ts
@@ -1,4 +1,6 @@
+import { locales, defaultLocale } from '@/config';
+
 export default {
-  locales: ['br', 'en'],
-  defaultLocale: 'br',
+  locales,
+  defaultLocale,
 };

--- a/i18n/request.ts
+++ b/i18n/request.ts
@@ -1,12 +1,13 @@
 import {getRequestConfig} from 'next-intl/server';
 import {routing} from './routing';
+import {defaultLocale} from '@/config';
  
 export default getRequestConfig(async ({requestLocale}) => {
   let locale = await requestLocale;
 
   if (!locale || !routing.locales.includes(locale as any)) {
-       locale = routing.defaultLocale;
-     }
+    locale = defaultLocale;
+  }
  
   let messages;
   try {

--- a/i18n/routing.ts
+++ b/i18n/routing.ts
@@ -1,15 +1,12 @@
 import {defineRouting} from 'next-intl/routing';
 import {createNavigation} from 'next-intl/navigation';
-import {locales} from '@/config';
+import {locales, defaultLocale} from '@/config';
 
 export const routing = defineRouting({
-  // A list of all locales that are supported
-  locales: locales,
- 
-  // Used when no locale matches
-  defaultLocale: 'br'
+  locales,
+  defaultLocale,
 });
 
 // Lightweight wrappers around Next.js' navigation APIs
 export const {Link, redirect, usePathname, useRouter} =
-  createNavigation({ defaultLocale: routing.defaultLocale });
+  createNavigation({ locales, defaultLocale });

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,9 +1,10 @@
-import { NextResponse } from "next/server";
-import type { NextRequest } from "next/server";
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { defaultLocale } from '@/config';
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
-  const locale = request.nextUrl.locale || "br";
+  const locale = request.nextUrl.locale || defaultLocale;
 
   // Redirect root URL to default locale
   if (pathname === "/") {


### PR DESCRIPTION
## Summary
- add `defaultLocale` to config and reuse in all i18n helpers
- ensure middleware and navigation use new default locale
- generate static params for all locales
- fix redirects to use current locale
- pass locale to social auth components

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687465b9d7848328aafdd0b20bd6acd9